### PR TITLE
Bump confluent-flink-table-api-python-plugin version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ example_08_integration_and_deployment = "flink_table_api_python.examples.table.e
 
 [tool.poetry.dependencies]
 python = ">= 3.9, < 3.12"
-confluent_flink_table_api_python_plugin = "1.20.38"
+confluent_flink_table_api_python_plugin = "1.20.48"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This version bump fixes an issue where clients were unable to use the library if connecting via PrivateLink.